### PR TITLE
Liteserver exit() fix

### DIFF
--- a/mypylib.py
+++ b/mypylib.py
@@ -455,7 +455,7 @@ class MyPyClass:
 		return data
 	#end define
 
-	def exit(self, signum, frame):
+	def exit(self, signum=None, frame=None):
 		self.working = False
 		if os.path.isfile(self.buffer.pid_file_path):
 			os.remove(self.buffer.pid_file_path)


### PR DESCRIPTION
This 2 arguments in exit() break ton liteserver, and also i couldn't find any usage of them. So i think it should be optional. 